### PR TITLE
Add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,10 @@
+{
+  "name": "patn-dev-stack",
+  "install": "bash .cursor/install.sh",
+  "terminals": [
+    {
+      "name": "dev",
+      "command": "npm run dev"
+    }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent bootstrap for the patn-dev-stack (Epic Stack) app.
+# Safe to run repeatedly: dependencies, database, and the Prisma client are
+# all reconciled from the checked-out source and committed migrations/seed.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# The app runs fully mocked in development; the example env has working values.
+if [ ! -f .env ]; then
+  cp .env.example .env
+fi
+
+# Reproducible dependency install from the committed lockfile.
+npm ci
+
+# Recreate the SQLite dev database from migrations and reseed it. `reset
+# --force` is idempotent and reruns the seed, giving every agent the same
+# admin user, about-me, skills, and project fixtures.
+npx prisma migrate reset --force --skip-generate
+
+# Generate the Prisma client, including the typed raw-SQL queries.
+npx prisma generate --sql


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up a Cloud Agent development environment for `patn-dev-stack` (Epic Stack / React Router v7 app). New agents will boot with dependencies installed, the SQLite database migrated and seeded, and the dev server running.

## Changes

- `.cursor/environment.json` — declares the `install` step and a `dev` terminal running `npm run dev` (fully mocked, `MOCKS=true`).
- `.cursor/install.sh` — idempotent bootstrap: creates `.env` from `.env.example` if missing, runs `npm ci`, resets/seeds the Prisma SQLite DB (`prisma migrate reset --force`), and generates the Prisma client with typed SQL (`prisma generate --sql`).

## Validation

All run on the current VM:

- `npm run typecheck` — passed
- `npm run lint` — passed (0 errors; 1 pre-existing warning)
- `npx vitest run` — 24/24 tests passed
- `npm run build` — client + server build succeeded
- Dev server end-to-end: homepage, `/resources/healthcheck` (200), DB-backed `/users?search=pat` returning seeded `Kody`/`pat`, and `/login` all verified in-browser
- Install idempotence: `install.sh` ran cleanly twice

[patn_dev_stack_end_to_end_walkthrough.mp4](https://cursor.com/agents/bc-62a60ee5-9716-4d26-b4e2-e71a2840e8a5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpatn_dev_stack_end_to_end_walkthrough.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62a60ee5-9716-4d26-b4e2-e71a2840e8a5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62a60ee5-9716-4d26-b4e2-e71a2840e8a5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

